### PR TITLE
feat: implement ASN.1 BER-TLV library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "ber-tlv",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ber-tlv",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "ber-tlv",
+  "version": "1.0.0",
+  "description": "Modern TypeScript library for ASN.1 BER-TLV encoding and decoding",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node --experimental-strip-types --test tests/*.test.ts",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "asn1",
+    "ber",
+    "tlv",
+    "ber-tlv",
+    "parser",
+    "encoder",
+    "decoder",
+    "emv",
+    "smartcard"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,253 @@
+/**
+ * ASN.1 BER-TLV encoding/decoding library
+ * Implements ISO/IEC 8825-1 / X.690 BER encoding rules for TLV structures
+ */
+
+/** Tag class as defined in ASN.1 */
+export const TagClass = {
+  Universal: 0b00,
+  Application: 0b01,
+  ContextSpecific: 0b10,
+  Private: 0b11,
+} as const;
+
+export type TagClass = (typeof TagClass)[keyof typeof TagClass];
+
+/** Parsed tag information */
+export interface Tag {
+  /** Tag number (decoded from potentially multi-byte representation) */
+  readonly number: number;
+  /** Whether this is a constructed (container) tag */
+  readonly constructed: boolean;
+  /** Tag class (Universal, Application, ContextSpecific, Private) */
+  readonly class: TagClass;
+  /** Raw tag bytes as they appear in the encoded data */
+  readonly bytes?: Uint8Array;
+}
+
+/** TLV structure */
+export interface Tlv {
+  /** Tag information */
+  readonly tag: Tag;
+  /** Value bytes (empty for constructed tags with children) */
+  readonly value: Uint8Array;
+  /** Child TLV elements for constructed tags */
+  readonly children?: readonly Tlv[];
+}
+
+/** Result of parsing a tag */
+export interface ParseTagResult {
+  readonly tag: Tag;
+  readonly bytesRead: number;
+}
+
+/** Result of parsing a length */
+export interface ParseLengthResult {
+  readonly length: number;
+  readonly bytesRead: number;
+}
+
+/**
+ * Parse a BER-TLV tag from the given data at the specified offset
+ */
+export function parseTag(data: Uint8Array, offset: number): ParseTagResult {
+  const firstByte = data[offset];
+  if (firstByte === undefined) {
+    throw new Error(`No data at offset ${offset}`);
+  }
+
+  const tagClass = ((firstByte >> 6) & 0b11) as TagClass;
+  const constructed = (firstByte & 0b00100000) !== 0;
+  const tagNumberPart = firstByte & 0b00011111;
+
+  // Single-byte tag
+  if (tagNumberPart !== 0b11111) {
+    return {
+      tag: {
+        number: tagNumberPart,
+        constructed,
+        class: tagClass,
+        bytes: new Uint8Array([firstByte]),
+      },
+      bytesRead: 1,
+    };
+  }
+
+  // Multi-byte tag: subsequent bytes have bit 7 as continuation flag
+  let tagNumber = 0;
+  let i = offset + 1;
+  const tagBytes: number[] = [firstByte];
+
+  while (i < data.length) {
+    const byte = data[i];
+    if (byte === undefined) {
+      throw new Error(`Unexpected end of data while parsing multi-byte tag`);
+    }
+    tagBytes.push(byte);
+    tagNumber = (tagNumber << 7) | (byte & 0x7f);
+    i++;
+    if ((byte & 0x80) === 0) {
+      break;
+    }
+  }
+
+  return {
+    tag: {
+      number: tagNumber,
+      constructed,
+      class: tagClass,
+      bytes: new Uint8Array(tagBytes),
+    },
+    bytesRead: tagBytes.length,
+  };
+}
+
+/**
+ * Encode a tag to BER-TLV bytes
+ */
+export function encodeTag(tag: Omit<Tag, "bytes">): Uint8Array {
+  const classBits = (tag.class << 6) & 0b11000000;
+  const constructedBit = tag.constructed ? 0b00100000 : 0;
+
+  // Single-byte tag (tag number fits in 5 bits, i.e., 0-30)
+  if (tag.number <= 30) {
+    return new Uint8Array([classBits | constructedBit | tag.number]);
+  }
+
+  // Multi-byte tag
+  const bytes: number[] = [classBits | constructedBit | 0b11111];
+
+  // Encode tag number in base-128 with continuation bits
+  const tagNumberBytes: number[] = [];
+  let remaining = tag.number;
+  while (remaining > 0) {
+    tagNumberBytes.unshift(remaining & 0x7f);
+    remaining >>= 7;
+  }
+
+  // Set continuation bit on all but the last byte
+  for (let i = 0; i < tagNumberBytes.length - 1; i++) {
+    tagNumberBytes[i]! |= 0x80;
+  }
+
+  bytes.push(...tagNumberBytes);
+  return new Uint8Array(bytes);
+}
+
+/**
+ * Parse a BER-TLV length from the given data at the specified offset
+ */
+export function parseLength(data: Uint8Array, offset: number): ParseLengthResult {
+  const firstByte = data[offset];
+  if (firstByte === undefined) {
+    throw new Error(`No data at offset ${offset}`);
+  }
+
+  // Short form: bit 7 is 0, bits 6-0 are the length
+  if ((firstByte & 0x80) === 0) {
+    return { length: firstByte, bytesRead: 1 };
+  }
+
+  // Long form: bit 7 is 1, bits 6-0 are the number of subsequent length bytes
+  const numLengthBytes = firstByte & 0x7f;
+
+  if (numLengthBytes === 0) {
+    throw new Error("Indefinite length not supported");
+  }
+
+  let length = 0;
+  for (let i = 0; i < numLengthBytes; i++) {
+    const byte = data[offset + 1 + i];
+    if (byte === undefined) {
+      throw new Error(`Unexpected end of data while parsing length`);
+    }
+    length = (length << 8) | byte;
+  }
+
+  return { length, bytesRead: 1 + numLengthBytes };
+}
+
+/**
+ * Encode a length to BER-TLV bytes
+ */
+export function encodeLength(length: number): Uint8Array {
+  if (length < 0) {
+    throw new Error("Length cannot be negative");
+  }
+
+  // Short form: lengths 0-127
+  if (length <= 127) {
+    return new Uint8Array([length]);
+  }
+
+  // Long form: determine number of bytes needed
+  const lengthBytes: number[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    lengthBytes.unshift(remaining & 0xff);
+    remaining >>= 8;
+  }
+
+  return new Uint8Array([0x80 | lengthBytes.length, ...lengthBytes]);
+}
+
+/**
+ * Parse BER-TLV encoded data into TLV structures
+ */
+export function parse(data: Uint8Array): Tlv[] {
+  const tlvs: Tlv[] = [];
+  let offset = 0;
+
+  while (offset < data.length) {
+    const { tag, bytesRead: tagBytesRead } = parseTag(data, offset);
+    offset += tagBytesRead;
+
+    const { length, bytesRead: lengthBytesRead } = parseLength(data, offset);
+    offset += lengthBytesRead;
+
+    const value = data.slice(offset, offset + length);
+    offset += length;
+
+    if (tag.constructed) {
+      const children = parse(value);
+      tlvs.push({ tag, value: new Uint8Array(), children });
+    } else {
+      tlvs.push({ tag, value });
+    }
+  }
+
+  return tlvs;
+}
+
+/**
+ * Encode TLV structures to BER-TLV bytes
+ */
+export function encode(tlvs: readonly Tlv[]): Uint8Array {
+  const chunks: Uint8Array[] = [];
+
+  for (const tlv of tlvs) {
+    const tagBytes = tlv.tag.bytes ?? encodeTag(tlv.tag);
+
+    let valueBytes: Uint8Array;
+    if (tlv.tag.constructed && tlv.children && tlv.children.length > 0) {
+      valueBytes = encode(tlv.children);
+    } else {
+      valueBytes = tlv.value;
+    }
+
+    const lengthBytes = encodeLength(valueBytes.length);
+
+    chunks.push(tagBytes, lengthBytes, valueBytes);
+  }
+
+  // Concatenate all chunks
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+}

--- a/tests/tlv.test.ts
+++ b/tests/tlv.test.ts
@@ -1,0 +1,212 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseTag,
+  encodeTag,
+  parseLength,
+  encodeLength,
+  parse,
+  encode,
+  type Tlv,
+  TagClass,
+} from "../src/index.ts";
+
+describe("Tag parsing", () => {
+  it("parses single-byte primitive tag", () => {
+    const data = new Uint8Array([0x01]);
+    const result = parseTag(data, 0);
+    assert.equal(result.tag.number, 0x01);
+    assert.equal(result.tag.constructed, false);
+    assert.equal(result.tag.class, TagClass.Universal);
+    assert.equal(result.bytesRead, 1);
+  });
+
+  it("parses single-byte constructed tag", () => {
+    const data = new Uint8Array([0x30]); // SEQUENCE
+    const result = parseTag(data, 0);
+    assert.equal(result.tag.number, 0x10);
+    assert.equal(result.tag.constructed, true);
+    assert.equal(result.tag.class, TagClass.Universal);
+  });
+
+  it("parses context-specific tag", () => {
+    const data = new Uint8Array([0x9f, 0x27]); // EMV tag 9F27
+    const result = parseTag(data, 0);
+    assert.equal(result.tag.number, 0x27);
+    assert.equal(result.tag.class, TagClass.ContextSpecific);
+    assert.equal(result.bytesRead, 2);
+  });
+
+  it("parses three-byte tag", () => {
+    const data = new Uint8Array([0x9f, 0x81, 0x02]); // Tag 9F8102
+    const result = parseTag(data, 0);
+    assert.equal(result.tag.number, 0x82);
+    assert.equal(result.bytesRead, 3);
+  });
+
+  it("returns raw bytes for tag", () => {
+    const data = new Uint8Array([0x9f, 0x27, 0x01, 0x00]);
+    const result = parseTag(data, 0);
+    assert.deepEqual(result.tag.bytes, new Uint8Array([0x9f, 0x27]));
+  });
+});
+
+describe("Tag encoding", () => {
+  it("encodes single-byte tag", () => {
+    const bytes = encodeTag({ number: 0x01, constructed: false, class: TagClass.Universal });
+    assert.deepEqual(bytes, new Uint8Array([0x01]));
+  });
+
+  it("encodes constructed tag", () => {
+    const bytes = encodeTag({ number: 0x10, constructed: true, class: TagClass.Universal });
+    assert.deepEqual(bytes, new Uint8Array([0x30]));
+  });
+
+  it("encodes multi-byte tag", () => {
+    const bytes = encodeTag({ number: 0x27, constructed: false, class: TagClass.ContextSpecific });
+    assert.deepEqual(bytes, new Uint8Array([0x9f, 0x27]));
+  });
+});
+
+describe("Length parsing", () => {
+  it("parses short form length", () => {
+    const data = new Uint8Array([0x05]);
+    const result = parseLength(data, 0);
+    assert.equal(result.length, 5);
+    assert.equal(result.bytesRead, 1);
+  });
+
+  it("parses zero length", () => {
+    const data = new Uint8Array([0x00]);
+    const result = parseLength(data, 0);
+    assert.equal(result.length, 0);
+    assert.equal(result.bytesRead, 1);
+  });
+
+  it("parses two-byte long form length", () => {
+    const data = new Uint8Array([0x81, 0x80]); // 128
+    const result = parseLength(data, 0);
+    assert.equal(result.length, 128);
+    assert.equal(result.bytesRead, 2);
+  });
+
+  it("parses three-byte long form length", () => {
+    const data = new Uint8Array([0x82, 0x01, 0x00]); // 256
+    const result = parseLength(data, 0);
+    assert.equal(result.length, 256);
+    assert.equal(result.bytesRead, 3);
+  });
+});
+
+describe("Length encoding", () => {
+  it("encodes short form length", () => {
+    const bytes = encodeLength(5);
+    assert.deepEqual(bytes, new Uint8Array([0x05]));
+  });
+
+  it("encodes length 127 as short form", () => {
+    const bytes = encodeLength(127);
+    assert.deepEqual(bytes, new Uint8Array([0x7f]));
+  });
+
+  it("encodes length 128 as long form", () => {
+    const bytes = encodeLength(128);
+    assert.deepEqual(bytes, new Uint8Array([0x81, 0x80]));
+  });
+
+  it("encodes length 256 as long form", () => {
+    const bytes = encodeLength(256);
+    assert.deepEqual(bytes, new Uint8Array([0x82, 0x01, 0x00]));
+  });
+});
+
+describe("TLV parsing", () => {
+  it("parses simple primitive TLV", () => {
+    const data = new Uint8Array([0x01, 0x02, 0xab, 0xcd]);
+    const tlvs = parse(data);
+    assert.equal(tlvs.length, 1);
+    assert.equal(tlvs[0]!.tag.number, 0x01);
+    assert.deepEqual(tlvs[0]!.value, new Uint8Array([0xab, 0xcd]));
+  });
+
+  it("parses multiple TLVs", () => {
+    const data = new Uint8Array([0x01, 0x01, 0xaa, 0x02, 0x01, 0xbb]);
+    const tlvs = parse(data);
+    assert.equal(tlvs.length, 2);
+    assert.deepEqual(tlvs[0]!.value, new Uint8Array([0xaa]));
+    assert.deepEqual(tlvs[1]!.value, new Uint8Array([0xbb]));
+  });
+
+  it("parses constructed TLV with children", () => {
+    // 30 06 01 01 AA 02 01 BB - SEQUENCE containing two primitives
+    const data = new Uint8Array([0x30, 0x06, 0x01, 0x01, 0xaa, 0x02, 0x01, 0xbb]);
+    const tlvs = parse(data);
+    assert.equal(tlvs.length, 1);
+    assert.equal(tlvs[0]!.tag.constructed, true);
+    assert.equal(tlvs[0]!.children?.length, 2);
+    assert.deepEqual(tlvs[0]!.children?.[0]?.value, new Uint8Array([0xaa]));
+  });
+
+  it("parses EMV-style multi-byte tag", () => {
+    // 9F27 01 80 - Cryptogram Information Data
+    const data = new Uint8Array([0x9f, 0x27, 0x01, 0x80]);
+    const tlvs = parse(data);
+    assert.equal(tlvs.length, 1);
+    assert.deepEqual(tlvs[0]!.tag.bytes, new Uint8Array([0x9f, 0x27]));
+  });
+
+  it("parses empty TLV", () => {
+    const data = new Uint8Array([0x01, 0x00]);
+    const tlvs = parse(data);
+    assert.equal(tlvs.length, 1);
+    assert.deepEqual(tlvs[0]!.value, new Uint8Array([]));
+  });
+});
+
+describe("TLV encoding", () => {
+  it("encodes simple primitive TLV", () => {
+    const tlv: Tlv = {
+      tag: { number: 0x01, constructed: false, class: TagClass.Universal },
+      value: new Uint8Array([0xab, 0xcd]),
+    };
+    const bytes = encode([tlv]);
+    assert.deepEqual(bytes, new Uint8Array([0x01, 0x02, 0xab, 0xcd]));
+  });
+
+  it("encodes multiple TLVs", () => {
+    const tlvs: Tlv[] = [
+      { tag: { number: 0x01, constructed: false, class: TagClass.Universal }, value: new Uint8Array([0xaa]) },
+      { tag: { number: 0x02, constructed: false, class: TagClass.Universal }, value: new Uint8Array([0xbb]) },
+    ];
+    const bytes = encode(tlvs);
+    assert.deepEqual(bytes, new Uint8Array([0x01, 0x01, 0xaa, 0x02, 0x01, 0xbb]));
+  });
+
+  it("encodes constructed TLV with children", () => {
+    const tlv: Tlv = {
+      tag: { number: 0x10, constructed: true, class: TagClass.Universal },
+      value: new Uint8Array(),
+      children: [
+        { tag: { number: 0x01, constructed: false, class: TagClass.Universal }, value: new Uint8Array([0xaa]) },
+        { tag: { number: 0x02, constructed: false, class: TagClass.Universal }, value: new Uint8Array([0xbb]) },
+      ],
+    };
+    const bytes = encode([tlv]);
+    assert.deepEqual(bytes, new Uint8Array([0x30, 0x06, 0x01, 0x01, 0xaa, 0x02, 0x01, 0xbb]));
+  });
+});
+
+describe("Roundtrip encoding/decoding", () => {
+  it("roundtrips complex nested structure", () => {
+    const original = new Uint8Array([
+      0x30, 0x0c,
+        0x01, 0x01, 0xaa,
+        0x30, 0x07,
+          0x02, 0x02, 0xbb, 0xcc,
+          0x03, 0x01, 0xdd,
+    ]);
+    const parsed = parse(original);
+    const encoded = encode(parsed);
+    assert.deepEqual(encoded, original);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary
- Implements ASN.1 BER-TLV encoding/decoding per ISO/IEC 8825-1 / X.690
- Supports single and multi-byte tags (up to 3 bytes)
- Supports short form (≤127) and long form length encoding
- Handles constructed (nested) TLV structures
- Modern TypeScript with strict mode, ESM, Node.js 22+

## Test Plan
- [x] Tag parsing tests (single-byte, multi-byte, constructed, context-specific)
- [x] Tag encoding tests
- [x] Length parsing tests (short form, long form)
- [x] Length encoding tests
- [x] Full TLV parsing tests (primitive, multiple, nested)
- [x] Full TLV encoding tests
- [x] Roundtrip test for complex nested structures
- 25 tests total, all passing

## Implementation Details
- Uses `Uint8Array` for binary data (no Node.js Buffer dependency)
- Immutable interfaces with `readonly` properties
- Const enum pattern for `TagClass`
- Zero runtime dependencies

Closes #1