### PR TITLE
docs: add reference to tomkp/emv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ This library implements BER-TLV encoding as defined in ISO/IEC 8825-1 / X.690.
 - **Short form** (0-127): Single byte, bit 7 = 0
 - **Long form** (128+): First byte = 0x80 | number of length bytes, followed by length bytes
 
+## Related Projects
+
+- [tomkp/emv](https://github.com/tomkp/emv) - Interactive EMV chip card explorer. EMV payment cards (Europay, MasterCard, Visa) use BER-TLV encoding extensively for application data, card responses, and cardholder verification. This project demonstrates real-world BER-TLV usage in the payment card industry.
+
 ## Requirements
 
 - Node.js 22+


### PR DESCRIPTION
## Summary

- Adds a new "Related Projects" section to the README
- References the tomkp/emv repository as a real-world example of BER-TLV usage
- Explains how EMV payment cards use BER-TLV encoding

## Why this is useful

The tomkp/emv project demonstrates practical BER-TLV usage in the payment card industry. EMV cards use BER-TLV extensively for:
- Application data structures
- Card response APDUs
- Cardholder verification data

This reference helps users understand how this library can be applied in practice.

Closes #11